### PR TITLE
Fixed edit attribute name selection for editing. Fixes #1142

### DIFF
--- a/src/decorators/OpIntDecorator/EasyDAG/OpIntDecorator.EasyDAGWidget.js
+++ b/src/decorators/OpIntDecorator/EasyDAG/OpIntDecorator.EasyDAGWidget.js
@@ -69,7 +69,7 @@ define([
         y = DecoratorBase.prototype.createAttributeFields.call(this, y, width);
         // Change attribute field so clicking allows user to edit/delete the field
         this.fields.forEach(field =>
-            field.onLabelClick = this.editAttributeMeta.bind(this, field.name));
+            field.onLabelClick = this.editAttributeMeta.bind(this, field.attr.name));
 
         // Add the 'create new attribute' field
         y += this.ROW_HEIGHT + (y === initialY ? 0 : 10);


### PR DESCRIPTION
Previously, this was causing issues opening attributes with display names that differed from the actual name (such as converting "_" to " " in the visual editor).