### PR TITLE
Handle null exit codes and no stdout. Fixes #1205

### DIFF
--- a/src/plugins/ExecuteJob/ExecuteJob.js
+++ b/src/plugins/ExecuteJob/ExecuteJob.js
@@ -640,7 +640,7 @@ define([
                                 // Download all files
                                 this.result.addArtifact(info.resultHashes[name + '-all-files']);
                                 // Parse the most precise error and present it in the toast...
-                                const lastline = result.stdout.split('\n').filter(l => !!l).pop();
+                                const lastline = result.stdout.split('\n').filter(l => !!l).pop() || '';
                                 if (lastline.includes('Error')) {
                                     this.onOperationFail(op, lastline); 
                                 } else {

--- a/src/plugins/GenerateJob/templates/start.ejs
+++ b/src/plugins/GenerateJob/templates/start.ejs
@@ -15,7 +15,7 @@ var COMMAND_PREFIX = '<%= CONSTANTS.START_CMD %>',
     IMAGE = '<%= CONSTANTS.IMAGE.PREFIX %>',
     requirejs = require('webgme').requirejs,
     remainingImageCount = 0,
-    exitCode = null;
+    exitCode;
 
 requirejs([
     'q',
@@ -79,7 +79,7 @@ requirejs([
     });
 
     var checkFinished = () => {
-        if (exitCode !== null && remainingImageCount === 0) {
+        if (exitCode !== undefined && remainingImageCount === 0) {
             log('finished!');
             cleanup();
         }
@@ -221,8 +221,13 @@ requirejs([
             log(`killing process group: ${pid}`);
             process.kill(-pid, 'SIGTERM');
         }
-        if (exitCode !== null) {
-            log(`exiting w/ code ${exitCode}`);
+        if (exitCode !== undefined) {
+            if (exitCode !== null) {
+                log(`exiting w/ code ${exitCode}`);
+            } else {  // exited involuntarily
+                log(`script exited involuntarily (exit code is null)`);
+                return process.exit(1);
+            }
             process.exit(exitCode);
         }
     };


### PR DESCRIPTION
This includes a workaround for https://github.com/webgme/executor-worker/issues/12 (https://github.com/deepforge-dev/deepforge/compare/1205-exit-code-null?expand=1#diff-ff6284b0c0e9936d7ea0b95ae89bb23cR229)