### PR TITLE
Update getOutputHashes -> {getDebugFilesHash,getResultsInfo} Fix #1330

### DIFF
--- a/src/common/compute/backends/ComputeClient.js
+++ b/src/common/compute/backends/ComputeClient.js
@@ -6,39 +6,32 @@ define([], function() {
     };
 
     ComputeClient.prototype.cancelJob = function(/*job*/) {
-        const msg = `cancelJob is not implemented for current compute backend!`;
-        this.logger.warn(msg);
-        throw new Error(msg);
-    };
-
-    ComputeClient.prototype.getInfo = function(/*job*/) {
-        const msg = `getInfo is not implemented for current compute backend!`;
-        this.logger.warn(msg);
-        throw new Error(msg);
+        unimplemented(this.logger, 'cancelJob');
     };
 
     ComputeClient.prototype.createJob = async function(/*hash*/) {
-        const msg = `createJob is not implemented for current compute backend!`;
-        this.logger.warn(msg);
-        throw new Error(msg);
+        unimplemented(this.logger, 'createJob');
     };
 
     ComputeClient.prototype.getStatus = async function(/*jobInfo*/) {
-        const msg = `getStatus is not implemented for current compute backend!`;
-        this.logger.warn(msg);
-        throw new Error(msg);
+        unimplemented(this.logger, 'getStatus');
     };
 
-    ComputeClient.prototype.getOutputHashes = async function(/*jobInfo*/) {
-        const msg = `getOutputHashes is not implemented for current compute backend!`;
-        this.logger.warn(msg);
-        throw new Error(msg);
+    ComputeClient.prototype.getDebugFilesHash = async function(/*jobInfo*/) {
+        unimplemented(this.logger, 'getDebugFilesHash');
+    };
+
+    ComputeClient.prototype.getResultsInfo = async function(/*jobInfo*/) {
+        unimplemented(this.logger, 'getResultsInfo');
     };
 
     ComputeClient.prototype.getConsoleOutput = async function(/*hash*/) {
-        const msg = `getConsoleOutput is not implemented for current compute backend!`;
-        this.logger.warn(msg);
-        throw new Error(msg);
+        unimplemented(this.logger, 'getConsoleOutput');
+    };
+
+    ComputeClient.prototype.isFinishedStatus = function(status) {
+        const notFinishedStatuses = [this.QUEUED, this.PENDING, this.RUNNING];
+        return !notFinishedStatuses.includes(status);
     };
 
     // Some functions for event support
@@ -60,6 +53,12 @@ define([], function() {
     ComputeClient.prototype.FAILED = 'failed';
     ComputeClient.prototype.CANCELED = 'canceled';
     ComputeClient.prototype.NOT_FOUND = 'NOT_FOUND';
+
+    function unimplemented(logger, name) {
+        const msg = `${name} is not implemented for current compute backend!`;
+        logger.error(msg);
+        throw new Error(msg);
+    }
 
     return ComputeClient;
 });

--- a/src/common/compute/backends/gme/Client.js
+++ b/src/common/compute/backends/gme/Client.js
@@ -1,16 +1,20 @@
 /* globals define */
 define([
     '../ComputeClient',
+    'blob/BlobClient',
     '../JobResults',
     './ExecutorHelper',
     'executor/ExecutorClient',
+    'common/util/assert',
     'path',
     'module',
 ], function(
     ComputeClient,
+    BlobClient,
     JobResults,
     ExecutorHelper,
     ExecutorClient,
+    assert,
     path,
     module,
 ) {
@@ -26,20 +30,55 @@ define([
             serverPort: gmeConfig.server.port,
             httpsecure: false
         });
+        this.blobClient = new BlobClient({
+            server: '127.0.0.1',
+            serverPort: gmeConfig.server.port,
+            httpsecure: false,
+            logger: this.logger.fork('BlobClient')
+        });
     };
     GMEExecutor.prototype = Object.create(ComputeClient.prototype);
 
-    GMEExecutor.prototype.getConsoleOutput = async function(hash) {
-        return (await this.executor.getOutput(hash))
-            .map(o => o.output).join('');
+    GMEExecutor.prototype.getConsoleOutput = async function(job) {
+        const info = await this.executor.getInfo(job.hash);
+        const isComplete = this.isFinishedStatus(this._getComputeStatus(info.status));
+
+        if (isComplete) {
+            const mdHash = await this._getResultHash(job, 'stdout');
+            const hash = await this._getContentHash(mdHash, 'job_stdout.txt');
+            assert(hash, 'Console output data not found.');
+            return await this.blobClient.getObjectAsString(hash);
+        } else {
+            return (await this.executor.getOutput(job.hash))
+                .map(o => o.output).join('');
+        }
     };
 
     GMEExecutor.prototype.cancelJob = function(job) {
         return this.executor.cancelJob(job.hash, job.secret);
     };
 
-    GMEExecutor.prototype.getOutputHashes = async function(job) {
-        return (await this.executor.getInfo(job.hash)).resultHashes;
+    GMEExecutor.prototype._getResultHash = async function(job, name) {
+        const {resultHashes} = await this.executor.getInfo(job.hash);
+        return resultHashes[name];
+    };
+
+    GMEExecutor.prototype.getResultsInfo = async function(job) {
+        const mdHash = await this._getResultHash(job, 'results');
+        const hash = await this._getContentHash(mdHash, 'results.json');
+        assert(hash, 'Metadata about result types not found.');
+        return await this.blobClient.getObjectAsJSON(hash);
+    };
+
+    GMEExecutor.prototype._getContentHash = async function (artifactHash, fileName) {
+        const artifact = await this.blobClient.getArtifact(artifactHash);
+        const contents = artifact.descriptor.content;
+
+        return contents[fileName] && contents[fileName].content;
+    };
+
+    GMEExecutor.prototype.getDebugFilesHash = async function(job) {
+        return await this._getResultHash(job, 'debug-files');
     };
 
     GMEExecutor.prototype.getStatus = async function(job) {
@@ -47,8 +86,7 @@ define([
         return this.getJobResultsFrom(info).status;
     };
 
-    GMEExecutor.prototype.getJobResultsFrom = function(gmeInfo) {
-        const gmeStatus = gmeInfo.status;
+    GMEExecutor.prototype._getComputeStatus = function(gmeStatus) {
         const gmeStatusToStatus = {
             'CREATED': this.QUEUED,
             'SUCCESS': this.SUCCESS,
@@ -56,7 +94,12 @@ define([
             'FAILED_TO_EXECUTE': this.FAILED,
             'RUNNING': this.RUNNING,
         };
-        return new JobResults(gmeStatusToStatus[gmeStatus] || gmeStatus);
+        return gmeStatusToStatus[gmeStatus] || gmeStatus;
+    };
+
+    GMEExecutor.prototype.getJobResultsFrom = function(gmeInfo) {
+        const gmeStatus = gmeInfo.status;
+        return new JobResults(this._getComputeStatus(gmeStatus));
     };
 
     GMEExecutor.prototype.getInfo = function(job) {

--- a/src/plugins/GenerateJob/GenerateJob.js
+++ b/src/plugins/GenerateJob/GenerateJob.js
@@ -149,7 +149,6 @@ define([
                 };
             });
 
-        const name = this.getAttribute(node, 'name');
         outputs.push(
             {
                 name: 'stdout',
@@ -160,7 +159,7 @@ define([
                 resultPatterns: ['results.json']
             },
             {
-                name: name + '-all-files',
+                name: 'debug-files',
                 resultPatterns: fileList
             }
         );


### PR DESCRIPTION
Removed `getOutputHashes` in favor of `getDebugFilesHash` and `getResultsInfo`. This also requires `getConsoleOutput` to work both when the job is running and after it completes.