### PR TITLE
Add initial version of SciServer compute backend. Closes #1309

### DIFF
--- a/config/components.json
+++ b/config/components.json
@@ -131,7 +131,7 @@
         ]
     },
     "Compute": {
-        "backends": ["gme", "local"]
+        "backends": ["gme", "local", "sciserver-compute"]
     },
     "Storage": {
         "backends": ["gme", "sciserver-files"]

--- a/src/common/compute/backends/sciserver-compute/Client.js
+++ b/src/common/compute/backends/sciserver-compute/Client.js
@@ -29,7 +29,6 @@ define([
         this.token = config.token;
         this.volume = config.volume;
         this.computeDomain = config.computeDomain;
-        this.token = '9876c76a742c4f2ebcf4c681630bb6f4';  // FIXME
 
         const gmeConfig = require.nodeRequire(GME_CONFIG_PATH);
         this.previousJobState = {};

--- a/src/common/compute/backends/sciserver-compute/Client.js
+++ b/src/common/compute/backends/sciserver-compute/Client.js
@@ -209,9 +209,8 @@ define([
         return JSON.parse(text);
     };
 
-    SciServerClient.prototype.getDebugFilesHash = async function(/*jobInfo*/) {
-        // TODO: Get the hash for the debug files...
-        return '';
+    SciServerClient.prototype.getDebugFilesHash = async function(jobInfo) {
+        return jobInfo.hash;
     };
 
     SciServerClient.prototype.getStatus = async function(jobInfo) {

--- a/src/common/compute/backends/sciserver-compute/Client.js
+++ b/src/common/compute/backends/sciserver-compute/Client.js
@@ -1,0 +1,287 @@
+/* globals define */
+define([
+    '../ComputeClient',
+    '../JobResults',
+    'deepforge/storage/index',
+    'blob/BlobClient',
+    'common/util/assert',
+    'module',
+    'path',
+    'node-fetch',
+    'text!./files/prepare-and-run.sh',
+], function(
+    ComputeClient,
+    JobResults,
+    Storage,
+    BlobClient,
+    assert,
+    module,
+    path,
+    fetch,
+    PREPARE_AND_RUN,
+) {
+    const Headers = fetch.Headers;
+    const POLL_INTERVAL = 1000;
+    const DEEPFORGE_ROOT = path.join(path.dirname(module.uri), '..', '..', '..', '..', '..');
+    const GME_CONFIG_PATH = path.join(DEEPFORGE_ROOT, 'config');
+    const SciServerClient = function(logger, config) {
+        ComputeClient.apply(this, arguments);
+        this.token = config.token;
+        this.volume = config.volume;
+        this.computeDomain = config.computeDomain;
+        this.token = '9876c76a742c4f2ebcf4c681630bb6f4';  // FIXME
+
+        const gmeConfig = require.nodeRequire(GME_CONFIG_PATH);
+        this.previousJobState = {};
+        this.consoleOutputLen = {};
+        this.blobClient = new BlobClient({
+            server: '127.0.0.1',
+            serverPort: gmeConfig.server.port,
+            httpsecure: false,
+            logger: this.logger.fork('BlobClient')
+        });
+    };
+
+    SciServerClient.prototype = Object.create(ComputeClient.prototype);
+
+    SciServerClient.prototype.createJob = async function(hash) {
+        const dirname = await this._uploadFiles(hash);
+        const job = await this._createJob(dirname);
+        const jobInfo = {
+            id: job.id,
+            hash,
+        };
+        this._poll(jobInfo);
+
+        return jobInfo;
+    };
+
+    SciServerClient.prototype._createConfig = async function(dirname) {
+        const domain = await this._getComputeDomain();
+        const userVolumes = domain.userVolumes.map(volume => ({
+            userVolumeId: volume.id,
+            needsWriteAccess: SciServerClient.isWritable(volume),
+        }));
+        const filepath = `/home/idies/workspace/Storage/${dirname}`;
+
+        return {
+            command: `bash ${filepath}/prepare-and-run.sh ${filepath}`,
+            dockerComputeEndpoint: domain.apiEndpoint,
+            dockerImageName: 'Python + R',
+            resultsFolderURI: '',
+            submitterDID: 'DeepForge Job',
+            volumeContainers: [],
+            userVolumes: userVolumes
+        };
+    };
+
+    SciServerClient.prototype._uploadFiles = async function(hash) {
+        const dirname = `execution-files/${hash}`;
+        const metadata = await this.blobClient.getMetadata(hash);
+        const config =  {
+            token: this.token,
+            volume: this.volume,
+        };
+        const storage = await Storage.getClient('sciserver-files', this.logger, config);
+        const files = Object.entries(metadata.content)
+            .map(async pair => {
+                const [filename, metadata] = pair;
+                const contents = await this.blobClient.getObject(metadata.content);
+                const filepath = `${dirname}/${filename}`;
+                await storage.putFile(filepath, contents);
+            });
+
+        await storage.putFile(`${dirname}/prepare-and-run.sh`, PREPARE_AND_RUN);
+        await Promise.all(files);
+        return `${config.volume}/${dirname}`;
+    };
+
+    SciServerClient.prototype._createJob = async function(dirname) {
+        const config = await this._createConfig(dirname);
+        const url = 'https://apps.sciserver.org/racm//jobm/rest/jobs/docker';
+
+        const opts = {
+            method: 'POST',
+            body: JSON.stringify(config),
+            headers: new Headers(),
+        };
+
+        opts.headers.append('Content-Type', 'application/json');
+
+        const response = await this.fetch(url, opts);
+        const {status} = response;
+        if (status === 400) {
+            throw new Error('Received "Bad Request" from SciServer. Is the token invalid?');
+        } else if (status > 399) {
+            const contents = await response.json();
+            throw new Error(`SciServer Files request failed: ${contents.error}`);
+        }
+        return await response.json();
+    };
+
+    SciServerClient.prototype.fetch = function(url, opts={}) {
+        opts.headers = opts.headers || new Headers();
+        opts.headers.append('X-Auth-Token', this.token);
+        return fetch(url, opts);
+    };
+
+    SciServerClient.prototype.getJobState = async function(jobInfo) {
+        const url = 'https://apps.sciserver.org/racm//jobm/rest/dockerjobs';
+
+        const opts = {
+            headers: new Headers(),
+        };
+        opts.headers.append('X-Auth-Token', this.token);
+
+        const response = await fetch(url, opts);
+        const {status} = response;
+        if (status === 400) {
+            throw new Error('Received "Bad Request" from SciServer. Is the token invalid?');
+        } else if (status > 399) {
+            const contents = await response.json();
+            throw new Error(`SciServer Files request failed: ${contents.error}`);
+        }
+
+        const results = await response.json();
+        return results.find(result => result.id === jobInfo.id);
+    };
+
+    SciServerClient.prototype.getJobResults = async function(jobInfo) {
+        const result = await this.getJobState(jobInfo);
+        if (result) {
+            const status = SciServerClient.getStatus(result.status);
+            return new JobResults(status);
+        }
+    };
+
+    SciServerClient.prototype._poll = async function(jobInfo) {
+        const state = await this.getJobState(jobInfo);
+        if (state) {
+            const status = SciServerClient.getStatus(state.status);
+            const prevState = this.previousJobState[jobInfo.id];
+            const prevStatus = prevState && SciServerClient.getStatus(prevState.status);
+
+            if (prevStatus !== status) {
+                this.emit('update', jobInfo.hash, status);
+            }
+
+            this.previousJobState[jobInfo.id] = state;
+            if (this.isFinishedStatus(status)) {
+                return this._onJobComplete(jobInfo, state);
+            } else if (status === this.RUNNING) {  // update stdout
+                const stdout = await this.getConsoleOutput(jobInfo);
+                const prevLen = this.consoleOutputLen[jobInfo.id] || 0;
+
+                this.emit('data', jobInfo.hash, stdout.substring(prevLen));
+                this.consoleOutputLen[jobInfo.id] = stdout.length;
+            }
+        }
+
+        return setTimeout(() => this._poll(jobInfo), POLL_INTERVAL);
+    };
+
+    SciServerClient.prototype._onJobComplete = async function(jobInfo, state) {
+        const {hash} = jobInfo;
+        const stdout = await this.getConsoleOutput(hash);
+        this.emit('data', hash, stdout);
+
+        const status = SciServerClient.getStatus(state.status);
+        const results = new JobResults(status);
+
+        if (status === this.SUCCESS) {
+            // TODO: Move the debug files to the blob
+        }
+
+        this._deleteFileDir(state);
+        this.emit('end', hash, results);
+        delete this.previousJobState[jobInfo.id];
+        delete this.consoleOutputLen[jobInfo.id];
+    };
+
+    SciServerClient.prototype.cancelJob = async function(jobInfo) {
+        const {id} = jobInfo;
+        const url = `https://apps.sciserver.org/racm/jobm/rest/jobs/${id}/cancel`;
+        await this.fetch(url, {method: 'POST'});
+    };
+
+    SciServerClient.prototype.getResultsInfo = async function(jobInfo) {
+        const text = await this._getFile(jobInfo, 'results.json');
+        assert(text, 'Metadata about result types not found.');
+        return JSON.parse(text);
+    };
+
+    SciServerClient.prototype.getDebugFilesHash = async function(/*jobInfo*/) {
+        // TODO: Get the hash for the debug files...
+        return '';
+    };
+
+    SciServerClient.prototype.getStatus = async function(jobInfo) {
+        const results = await this.getJobResults(jobInfo);
+        return results && results.status;
+    };
+
+    SciServerClient.prototype.getConsoleOutput = async function(jobInfo) {
+        return await this._getFile(jobInfo, 'stdout.txt') || '';
+    };
+
+    SciServerClient.prototype._getFile = async function(jobInfo, filename) {
+        const state = await this.getJobState(jobInfo);
+        if (state) {
+            const baseUrl = 'https://apps.sciserver.org/fileservice/api/file/';
+            const filepath = state.resultsFolderURI.replace(/\/?$/, '/') + filename;
+            const fileUrl = baseUrl + this._getEncodedFilePath(filepath);
+
+            const response = await this.fetch(fileUrl);
+            return await response.text();
+        }
+    };
+
+    SciServerClient.prototype._deleteFileDir = async function(state) {
+        const baseUrl = 'https://apps.sciserver.org/fileservice/api/data/';
+        const filepath = state.command.split(' ').pop();
+        const fileUrl = baseUrl + this._getEncodedFilePath(filepath);
+        const response = await this.fetch(fileUrl, {method: 'DELETE'});
+        return await response.text();
+    };
+
+    SciServerClient.prototype._getEncodedFilePath = function(filepath) {
+        const dirs = filepath.split('/').slice(4);
+        const filename = dirs.pop();
+        const drive = dirs.slice(0, 3).join('/') + '/';
+        const dirname = '/' + dirs.slice(3).join('/');
+
+        return drive + encodeURIComponent(dirname) + '/' + filename;
+    };
+
+    SciServerClient.prototype._getComputeDomain = async function() {
+        const url = 'https://apps.sciserver.org/racm/jobm/rest/computedomains?batch=true';
+        const response = await this.fetch(url);
+        const domains = await response.json();
+
+        const domain = domains.find(domain => domain.name === this.computeDomain);
+        assert(domain, `Compute domain not found: ${this.computeDomain}`);
+        return domain;
+    };
+
+    SciServerClient.getStatus = function(code) {
+        const index = Math.log2(code);
+        return SciServerClient.STATUSES[index];
+    };
+
+    SciServerClient.STATUSES = [
+        ComputeClient.prototype.QUEUED,
+        ComputeClient.prototype.PENDING,
+        ComputeClient.prototype.PENDING,
+        ComputeClient.prototype.RUNNING,
+        ComputeClient.prototype.RUNNING,
+        ComputeClient.prototype.SUCCESS,
+        ComputeClient.prototype.FAILED,
+        ComputeClient.prototype.CANCELED,
+    ];
+
+    SciServerClient.isWritable = function(volume) {
+        return volume.allowedActions.includes('write');
+    };
+
+    return SciServerClient;
+});

--- a/src/common/compute/backends/sciserver-compute/Client.js
+++ b/src/common/compute/backends/sciserver-compute/Client.js
@@ -269,8 +269,8 @@ define([
 
     SciServerClient.STATUSES = [
         ComputeClient.prototype.QUEUED,
-        ComputeClient.prototype.PENDING,
-        ComputeClient.prototype.PENDING,
+        ComputeClient.prototype.QUEUED,
+        ComputeClient.prototype.QUEUED,
         ComputeClient.prototype.RUNNING,
         ComputeClient.prototype.RUNNING,
         ComputeClient.prototype.SUCCESS,

--- a/src/common/compute/backends/sciserver-compute/files/prepare-and-run.sh
+++ b/src/common/compute/backends/sciserver-compute/files/prepare-and-run.sh
@@ -1,10 +1,9 @@
-echo "node version is $(node -v)"
 RESULTS_DIR=$(pwd)
 JOB_DIR=$1
 
 cd $JOB_DIR;
-npm install requirejs@2.3.5 rimraf@^2.4.0 superagent@3.8.3 @babel/runtime@^7.7.2 q@1.5.1 node-fetch@2.6.0 agentkeepalive@3.4.1
-pip install simplejson
+npm install requirejs@2.3.5 rimraf@^2.4.0 superagent@3.8.3 @babel/runtime@^7.7.2 q@1.5.1 node-fetch@2.6.0 agentkeepalive@3.4.1 > /dev/null
+pip install simplejson > /dev/null
 
 node start.js
 cp $JOB_DIR/results.json $RESULTS_DIR/results.json

--- a/src/common/compute/backends/sciserver-compute/files/prepare-and-run.sh
+++ b/src/common/compute/backends/sciserver-compute/files/prepare-and-run.sh
@@ -1,0 +1,10 @@
+echo "node version is $(node -v)"
+RESULTS_DIR=$(pwd)
+JOB_DIR=$1
+
+cd $JOB_DIR;
+npm install requirejs@2.3.5 rimraf@^2.4.0 superagent@3.8.3 @babel/runtime@^7.7.2 q@1.5.1 node-fetch@2.6.0 agentkeepalive@3.4.1
+pip install simplejson
+
+node start.js
+cp $JOB_DIR/results.json $RESULTS_DIR/results.json

--- a/src/common/compute/backends/sciserver-compute/metadata.json
+++ b/src/common/compute/backends/sciserver-compute/metadata.json
@@ -1,0 +1,33 @@
+{
+    "name": "SciServer Compute",
+    "dashboard": null,
+    "client": "./Client",
+    "configStructure": [
+        {
+            "name": "token",
+            "displayName": "Access Token",
+            "description": "SciServer access token.",
+            "value": "",
+            "valueType": "string",
+            "readOnly": false
+        },
+        {
+            "name": "volume",
+            "displayName": "Volume",
+            "description": "Volume to use for upload.",
+            "value": "USERNAME/deepforge_data",
+            "valueType": "string",
+            "readOnly": false
+        },
+        {
+            "name": "computeDomain",
+            "displayName": "Compute Domain",
+            "description": "A small job shares resources with up to 4 other jobs and has a max quota for RAM of approx 32GB. A large job runs exclusively and has all CPU cores and RAM available (approx 240GB), however since only one large job will run at a time, there may be a longer wait for the job to start.",
+            "value": "Small Jobs Domain",
+            "valueItems": [
+                "Small Jobs Domain",
+                "Large Jobs Domain"
+            ]
+        }
+    ]
+}

--- a/src/common/compute/index.js
+++ b/src/common/compute/index.js
@@ -1,6 +1,6 @@
 /*globals define, requirejs */
 (function() {
-    const COMPUTE_BACKENDS = ['gme', 'local'];
+    const COMPUTE_BACKENDS = ['gme', 'local', 'sciserver-compute'];
     define([
         'module',
         'deepforge/compute/backends/ComputeBackend',

--- a/src/plugins/GenerateJob/templates/utils.build.js
+++ b/src/plugins/GenerateJob/templates/utils.build.js
@@ -2325,8 +2325,6 @@ define('deepforge/storage/index',['module', './backends/StorageBackend', 'text!d
       ComponentSettings.resolveWithWebGMEGlobal(settings, this.getComponentId());
     } else {
       // Running in NodeJS
-      console.log('>>> about to get the components.js');
-
       var path = require('path');
 
       var dirname = path.dirname(module.uri);
@@ -2826,6 +2824,8 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 
 var _regenerator = _interopRequireDefault(require("@babel/runtime/regenerator"));
 
+var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));
+
 /* globals define */
 define('deepforge/storage/backends/gme/Client',['../StorageClient', 'blob/BlobClient', 'deepforge/gmeConfig'], function (StorageClient, BlobClient, gmeConfig) {
   var GMEStorage = function GMEStorage()
@@ -2837,15 +2837,26 @@ define('deepforge/storage/backends/gme/Client',['../StorageClient', 'blob/BlobCl
     };
 
     if (!require.isBrowser) {
-      params.server = '127.0.0.1';
-      params.serverPort = gmeConfig.server.port;
-      params.httpsecure = false;
+      var _this$getServerURL = this.getServerURL(),
+          _this$getServerURL2 = (0, _slicedToArray2["default"])(_this$getServerURL, 2),
+          url = _this$getServerURL2[0],
+          isHttps = _this$getServerURL2[1];
+
+      params.server = url.split(':')[0];
+      params.serverPort = +url.split(':').pop();
+      params.httpsecure = isHttps;
     }
 
     this.blobClient = new BlobClient(params);
   };
 
   GMEStorage.prototype = Object.create(StorageClient.prototype);
+
+  GMEStorage.prototype.getServerURL = function () {
+    var port = gmeConfig.server.port;
+    var url = process.env.DEEPFORGE_URL || "127.0.0.1:".concat(port);
+    return [url.replace(/^https?:\/\//, ''), url.startsWith('https')];
+  };
 
   GMEStorage.prototype.getFile = function _callee(dataInfo) {
     var data;


### PR DESCRIPTION
This PR adds an initial version of a compute backend for SciServer (using the jobs API). However, this does not include support for:
- Uploading files to scratch volumes instead of persistent storage volumes #1349 
- ~~Debug files support (downloading the files to run locally)~~
- Compute dashboard (it would be nice to at least link to the SciServer Jobs dashboard - preferably with a filter for all the deepforge jobs.) #1350 
- Generating code for an entire pipeline #1351

Additionally, this exposed an issue with the GME storage backend as the client currently assumes it is running on same machine as the server. This needs to be fixed so the job running remotely can upload the results to the WebGME blob hosted by DeepForge (when using this backend, of course).