### PR TITLE
Add default text for Executions with no Metadata. Fixes #1363.

### DIFF
--- a/src/visualizers/panels/ExecutionIndex/ExecutionIndexControl.js
+++ b/src/visualizers/panels/ExecutionIndex/ExecutionIndexControl.js
@@ -49,9 +49,10 @@ define([
     };
 
     ExecutionIndexControl.prototype._updateGraphWidget = function () {
-        if(this.displayedExecCount() > 0){
-            const plotlyJSON = this._consolidateGraphData(this.displayedExecutions);
-            if(plotlyJSON) this._widget.updateNode(plotlyJSON);
+        const plotlyJSON = this._consolidateGraphData(this.displayedExecutions);
+        const hasDisplayedMetadata = !!plotlyJSON;
+        if (hasDisplayedMetadata) {
+            this._widget.updateNode(plotlyJSON);
         } else {
             this._widget.removeNode();
         }
@@ -78,7 +79,7 @@ define([
             graphDescs.forEach((desc) => {
                 if (!consolidatedDesc) {
                     consolidatedDesc = JSON.parse(JSON.stringify(desc));
-                    consolidatedDesc.subGraphs.forEach((subGraph) =>{
+                    consolidatedDesc.subGraphs.forEach((subGraph) => {
                         subGraph.abbr = desc.abbr;
                         subGraph.title = getDisplayTitle(subGraph, true);
                     });

--- a/src/visualizers/panels/ExecutionIndex/ExecutionIndexControl.js
+++ b/src/visualizers/panels/ExecutionIndex/ExecutionIndexControl.js
@@ -49,12 +49,9 @@ define([
     };
 
     ExecutionIndexControl.prototype._updateGraphWidget = function () {
-        if (this.displayedExecCount() > 0) {
-            const plotlyJSON = this._consolidateGraphData(this.displayedExecutions);
-            this._widget.updateNode(plotlyJSON);
-        } else {
-            this._widget.removeNode();
-        }
+        const plotlyJSON = this._consolidateGraphData(this.displayedExecutions);
+        if(plotlyJSON) this._widget.updateNode(plotlyJSON);
+        else this._widget.removeNode();
     };
 
     ExecutionIndexControl.prototype._consolidateGraphData = function (graphExecIDs) {

--- a/src/visualizers/panels/ExecutionIndex/ExecutionIndexControl.js
+++ b/src/visualizers/panels/ExecutionIndex/ExecutionIndexControl.js
@@ -49,9 +49,12 @@ define([
     };
 
     ExecutionIndexControl.prototype._updateGraphWidget = function () {
-        const plotlyJSON = this._consolidateGraphData(this.displayedExecutions);
-        if(plotlyJSON) this._widget.updateNode(plotlyJSON);
-        else this._widget.removeNode();
+        if(this.displayedExecCount() > 0){
+            const plotlyJSON = this._consolidateGraphData(this.displayedExecutions);
+            if(plotlyJSON) this._widget.updateNode(plotlyJSON);
+        } else {
+            this._widget.removeNode();
+        }
     };
 
     ExecutionIndexControl.prototype._consolidateGraphData = function (graphExecIDs) {

--- a/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
+++ b/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
@@ -38,11 +38,7 @@ define(['./lib/plotly.min',], function (Plotly) {
 
     // Adding/Removing/Updating items
     PlotlyGraphWidget.prototype.addNode = function (desc) {
-        if (desc) {
-            this.plotlyJSON = desc;
-            this.setTextVisibility(false);
-            this.refreshChart();
-        }
+        this.addOrUpdateNode(desc);
     };
 
     PlotlyGraphWidget.prototype.removeNode = function () {
@@ -51,12 +47,16 @@ define(['./lib/plotly.min',], function (Plotly) {
         this.setTextVisibility();
     };
 
-    PlotlyGraphWidget.prototype.updateNode = function (desc) {
+    PlotlyGraphWidget.prototype.addOrUpdateNode = function (desc) {
         if (desc) {
             this.plotlyJSON = desc;
             this.setTextVisibility(false);
             this.refreshChart();
         }
+    };
+
+    PlotlyGraphWidget.prototype.updateNode = function (desc) {
+        this.addOrUpdateNode(desc);
     };
 
     PlotlyGraphWidget.prototype.createOrUpdateChart = function () {

--- a/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
+++ b/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
@@ -1,4 +1,4 @@
-/*globals define, _*/
+/*globals define, _, $*/
 define(['./lib/plotly.min',], function (Plotly) {
     'use strict';
 

--- a/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
+++ b/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
@@ -13,7 +13,7 @@ define(['./lib/plotly.min',], function (Plotly) {
             .css({
                 'margin-top': this.$el.height() / 2
             });
-
+        this.$el.append(this.$defaultTextDiv);
         this.$el.css('overflow', 'auto');
         this.$el.addClass(WIDGET_CLASS);
         this.nodes = {};
@@ -21,7 +21,7 @@ define(['./lib/plotly.min',], function (Plotly) {
         this.layout = {};
         this.created = false;
         this.logger.debug('ctor finished');
-        this.toggleText();
+        this.setTextVisibility();
     }
 
     PlotlyGraphWidget.prototype.onWidgetContainerResize = function (width, height) {
@@ -40,6 +40,7 @@ define(['./lib/plotly.min',], function (Plotly) {
     PlotlyGraphWidget.prototype.addNode = function (desc) {
         if (desc) {
             this.plotlyJSON = desc;
+            this.setTextVisibility(false);
             this.refreshChart();
         }
     };
@@ -47,11 +48,13 @@ define(['./lib/plotly.min',], function (Plotly) {
     PlotlyGraphWidget.prototype.removeNode = function () {
         this.plotlyJSON = null;
         this.refreshChart();
+        this.setTextVisibility();
     };
 
     PlotlyGraphWidget.prototype.updateNode = function (desc) {
         if (desc) {
             this.plotlyJSON = desc;
+            this.setTextVisibility(false);
             this.refreshChart();
         }
     };
@@ -61,7 +64,6 @@ define(['./lib/plotly.min',], function (Plotly) {
             this.deleteChart();
         } else {
             if (!this.created && !_.isEmpty(this.plotlyJSON)) {
-                this.toggleText(false);
                 Plotly.newPlot(this.$el[0], this.plotlyJSON);
                 this.created = true;
             } else if (!_.isEmpty(this.plotlyJSON)) {
@@ -76,14 +78,13 @@ define(['./lib/plotly.min',], function (Plotly) {
         this.plotlyJSON = null;
         if (this.created) {
             Plotly.purge(this.$el[0]);
-            this.toggleText();
         }
         this.created = false;
     };
 
-    PlotlyGraphWidget.prototype.toggleText = function (append = true) {
-        if (append) this.$el.append(this.$defaultTextDiv);
-        else this.$defaultTextDiv.remove();
+    PlotlyGraphWidget.prototype.setTextVisibility = function (display = true) {
+        display = display ? 'block' : 'none';
+        this.$defaultTextDiv.css('display', display);
     };
     /* * * * * * * * Visualizer life cycle callbacks * * * * * * * */
     PlotlyGraphWidget.prototype.destroy = function () {

--- a/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
+++ b/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
@@ -7,6 +7,13 @@ define(['./lib/plotly.min',], function (Plotly) {
     function PlotlyGraphWidget(logger, container) {
         this.logger = logger.fork('widget');
         this.$el = container;
+        this.$defaultTextDiv = $('<div>', {
+            class: 'h2 center'
+        }).text('No Data Available.')
+            .css({
+                'margin-top': this.$el.height() / 2
+            });
+
         this.$el.css('overflow', 'auto');
         this.$el.addClass(WIDGET_CLASS);
         this.nodes = {};
@@ -14,6 +21,7 @@ define(['./lib/plotly.min',], function (Plotly) {
         this.layout = {};
         this.created = false;
         this.logger.debug('ctor finished');
+        this.toggleText();
     }
 
     PlotlyGraphWidget.prototype.onWidgetContainerResize = function (width, height) {
@@ -21,6 +29,9 @@ define(['./lib/plotly.min',], function (Plotly) {
         this.$el.css({
             width: width,
             height: height
+        });
+        this.$defaultTextDiv.css({
+            'margin-top': height / 2
         });
         this.logger.debug('Widget is resizing...');
     };
@@ -50,9 +61,10 @@ define(['./lib/plotly.min',], function (Plotly) {
             this.deleteChart();
         } else {
             if (!this.created && !_.isEmpty(this.plotlyJSON)) {
+                this.toggleText(false);
                 Plotly.newPlot(this.$el[0], this.plotlyJSON);
                 this.created = true;
-            } else if(!_.isEmpty(this.plotlyJSON)) {
+            } else if (!_.isEmpty(this.plotlyJSON)) {
                 Plotly.react(this.$el[0], this.plotlyJSON);
             }
         }
@@ -64,10 +76,15 @@ define(['./lib/plotly.min',], function (Plotly) {
         this.plotlyJSON = null;
         if (this.created) {
             Plotly.purge(this.$el[0]);
+            this.toggleText();
         }
         this.created = false;
     };
 
+    PlotlyGraphWidget.prototype.toggleText = function (append = true) {
+        if (append) this.$el.append(this.$defaultTextDiv);
+        else this.$defaultTextDiv.remove();
+    };
     /* * * * * * * * Visualizer life cycle callbacks * * * * * * * */
     PlotlyGraphWidget.prototype.destroy = function () {
         Plotly.purge(this.$el[0]);

--- a/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
+++ b/src/visualizers/widgets/PlotlyGraph/PlotlyGraphWidget.js
@@ -21,7 +21,7 @@ define(['./lib/plotly.min',], function (Plotly) {
         this.layout = {};
         this.created = false;
         this.logger.debug('ctor finished');
-        this.setTextVisibility();
+        this.setTextVisibility(true);
     }
 
     PlotlyGraphWidget.prototype.onWidgetContainerResize = function (width, height) {
@@ -44,7 +44,7 @@ define(['./lib/plotly.min',], function (Plotly) {
     PlotlyGraphWidget.prototype.removeNode = function () {
         this.plotlyJSON = null;
         this.refreshChart();
-        this.setTextVisibility();
+        this.setTextVisibility(true);
     };
 
     PlotlyGraphWidget.prototype.addOrUpdateNode = function (desc) {
@@ -82,7 +82,7 @@ define(['./lib/plotly.min',], function (Plotly) {
         this.created = false;
     };
 
-    PlotlyGraphWidget.prototype.setTextVisibility = function (display = true) {
+    PlotlyGraphWidget.prototype.setTextVisibility = function (display) {
         display = display ? 'block' : 'none';
         this.$defaultTextDiv.css('display', display);
     };


### PR DESCRIPTION
To Fix #1363, This PR Updates the plotly graph widget to have a default text and not throw an error on `ExecutionIndex` Widget.
![image](https://user-images.githubusercontent.com/11476842/69754832-751fdb80-111c-11ea-80aa-2c35fe4f8f1f.png)
