### PR TITLE
Prompt user for auth on artifact delete, download. Closes #1422, #1415

### DIFF
--- a/src/common/storage/backends/sciserver-files/metadata.json
+++ b/src/common/storage/backends/sciserver-files/metadata.json
@@ -7,7 +7,8 @@
             "description": "SciServer access token.",
             "value": "",
             "valueType": "string",
-            "readOnly": false
+            "readOnly": false,
+            "isAuth": true
         },
         {
             "name": "volume",

--- a/src/visualizers/panels/ArtifactIndex/ArtifactIndexControl.js
+++ b/src/visualizers/panels/ArtifactIndex/ArtifactIndexControl.js
@@ -3,10 +3,12 @@
 
 define([
     'deepforge/storage/index',
+    'deepforge/viz/ConfigDialog',
     'blob/BlobClient',
     'js/Constants'
 ], function (
     Storage,
+    ConfigDialog,
     BlobClient,
     CONSTANTS
 ) {
@@ -42,9 +44,15 @@ define([
             // WebGMEGlobal.State.registerActiveObject(id);
         };
 
-        this._widget.onNodeDeleteClicked = id => {
-            var name = this._client.getNode(id).getAttribute('name'),
-                msg = `Deleted "${name}" artifact (${id}) --`;
+        this._widget.onNodeDeleteClicked = async (id, config) => {
+            const node = this._client.getNode(id);
+            const name = node.getAttribute('name');
+            const msg = `Deleted "${name}" artifact (${id})`;
+
+            const dataInfo = this.getDataInfo(node);
+            const {backend} = dataInfo;
+            const storage = await Storage.getClient(backend, this._logger, config);
+            await storage.deleteFile(dataInfo);
 
             this._client.startTransaction(msg);
             this._client.deleteNode(id);
@@ -59,6 +67,7 @@ define([
 
             return await storage.getDownloadURL(dataInfo);
         };
+        this._widget.getConfigDialog = () => new ConfigDialog(this._client);
 
         this._widget.onNameChange = (id, newName) => {
             var name = this._client.getNode(id).getAttribute('name'),

--- a/src/visualizers/widgets/ArtifactIndex/ArtifactIndexWidget.js
+++ b/src/visualizers/widgets/ArtifactIndex/ArtifactIndexWidget.js
@@ -3,10 +3,14 @@
 
 define([
     './ModelItem',
+    'panel/FloatingActionButton/styles/Materialize',
+    'deepforge/storage/index',
     'text!./Table.html',
     'css!./styles/ArtifactIndexWidget.css'
 ], function (
     ModelItem,
+    Materialize,
+    Storage,
     TABLE_HTML
 ) {
     'use strict';
@@ -43,14 +47,25 @@ define([
         if (desc && desc.parentId === this.currentNode) {
             var node = new ModelItem(this.$list, desc);
             this.nodes[desc.id] = node;
-            node.$delete.on('click', event => {
-                this.onNodeDeleteClicked(desc.id);
+            node.$delete.on('click', async event => {
+                const config = await this.getAuthenticationConfig(desc.dataInfo);
+                if (config !== null) {
+                    this.onNodeDeleteClicked(desc.id, config);
+                }
                 event.stopPropagation();
                 event.preventDefault();
             });
             node.$download.on('click', async event => {
-                const url = await this.getDownloadURL(desc.id);
-                this.download(desc.name, url);
+                const config = await this.getAuthenticationConfig(desc.dataInfo);
+                if (config !== null) {
+                    try {
+                        const url = await this.getDownloadURL(desc.id, config);
+                        this.download(desc.name, url);
+                    } catch (err) {
+                        const msg = `Unable to fetch data: ${err.message}`;
+                        Materialize.toast(msg, 4000);
+                    }
+                }
                 event.stopPropagation();
                 event.preventDefault();
             });
@@ -73,6 +88,20 @@ define([
                 });
             });
         }
+    };
+
+    ArtifactIndexWidget.prototype.getAuthenticationConfig = async function (dataInfo) {
+        const {backend} = dataInfo;
+        const metadata = Storage.getStorageMetadata(backend);
+        metadata.configStructure = metadata.configStructure
+            .filter(option => option.isAuth);
+
+        const configDialog = this.getConfigDialog();
+        const title = `Authenticate with ${metadata.name}`;
+        const iconClass = `glyphicon glyphicon-download-alt`;
+        const config = await configDialog.show(metadata, {title, iconClass});
+
+        return config[backend];
     };
 
     ArtifactIndexWidget.prototype.removeNode = function (gmeId) {

--- a/src/visualizers/widgets/ArtifactIndex/ArtifactIndexWidget.js
+++ b/src/visualizers/widgets/ArtifactIndex/ArtifactIndexWidget.js
@@ -49,22 +49,18 @@ define([
             this.nodes[desc.id] = node;
             node.$delete.on('click', async event => {
                 const config = await this.getAuthenticationConfig(desc.dataInfo);
-                if (config !== null) {
-                    this.onNodeDeleteClicked(desc.id, config);
-                }
+                this.onNodeDeleteClicked(desc.id, config);
                 event.stopPropagation();
                 event.preventDefault();
             });
             node.$download.on('click', async event => {
                 const config = await this.getAuthenticationConfig(desc.dataInfo);
-                if (config !== null) {
-                    try {
-                        const url = await this.getDownloadURL(desc.id, config);
-                        this.download(desc.name, url);
-                    } catch (err) {
-                        const msg = `Unable to fetch data: ${err.message}`;
-                        Materialize.toast(msg, 4000);
-                    }
+                try {
+                    const url = await this.getDownloadURL(desc.id, config);
+                    this.download(desc.name, url);
+                } catch (err) {
+                    const msg = `Unable to fetch data: ${err.message}`;
+                    Materialize.toast(msg, 4000);
                 }
                 event.stopPropagation();
                 event.preventDefault();
@@ -96,12 +92,14 @@ define([
         metadata.configStructure = metadata.configStructure
             .filter(option => option.isAuth);
 
-        const configDialog = this.getConfigDialog();
-        const title = `Authenticate with ${metadata.name}`;
-        const iconClass = `glyphicon glyphicon-download-alt`;
-        const config = await configDialog.show(metadata, {title, iconClass});
+        if (metadata.configStructure.length) {
+            const configDialog = this.getConfigDialog();
+            const title = `Authenticate with ${metadata.name}`;
+            const iconClass = `glyphicon glyphicon-download-alt`;
+            const config = await configDialog.show(metadata, {title, iconClass});
 
-        return config[backend];
+            return config[backend];
+        }
     };
 
     ArtifactIndexWidget.prototype.removeNode = function (gmeId) {


### PR DESCRIPTION
This also adds the `isAuth` key to the storage configuration options which is used to designate configuration options for authentication. These options are provided to the user when downloading or deleting the data as well.