### PR TITLE
Add default impl for getDownloadURL using the browser blob. Close #1425

### DIFF
--- a/src/common/storage/backends/StorageClient.js
+++ b/src/common/storage/backends/StorageClient.js
@@ -60,9 +60,14 @@ define([
         throw new Error(`Directory deletion not supported by ${this.name}`);
     };
 
-    StorageClient.prototype.getDownloadURL = async function(/*dataInfo*/) {
-        // TODO: Remove this in favor of directly downloading w/ getFile, etc
-        throw new Error(`getDownloadURL not implemented for ${this.name}`);
+    StorageClient.prototype.getDownloadURL = async function(dataInfo) {
+        if (require.isBrowser) {
+            const data = await this.getFile(dataInfo);
+            const url = window.URL.createObjectURL(new Blob([data]));
+            return url;
+        } else {
+            throw new Error(`getDownloadURL not implemented for ${this.name}`);
+        }
     };
 
     StorageClient.prototype.getMetadata = async function(/*dataInfo*/) {

--- a/src/common/storage/backends/sciserver-files/Client.js
+++ b/src/common/storage/backends/sciserver-files/Client.js
@@ -67,11 +67,6 @@ define([
         return metadata;
     };
 
-    SciServerFiles.prototype.getDownloadURL = async function (dataInfo) {
-        const {data} = dataInfo;
-        return data.url;
-    };
-
     SciServerFiles.prototype.getCachePath = async function (dataInfo) {
         const {volume, filename} = dataInfo.data;
         return `${this.id}/${volume}/${filename}`;

--- a/src/plugins/GenerateJob/GenerateJob.js
+++ b/src/plugins/GenerateJob/GenerateJob.js
@@ -104,32 +104,11 @@ define([
     }; 
 
     GenerateJob.prototype.createRunScript = async function (files) {
-        let runsh = [
-            '# Bash script to download data files and run job',
-            !this.settings.enableJobCaching ? `# Created at ${Date.now()}` : '',
-            'if [ -z "$DEEPFORGE_URL" ]; then',
-            '  echo "Please set DEEPFORGE_URL and re-run:"',
-            '  echo ""',
-            '  echo "  DEEPFORGE_URL=http://my.deepforge.server.com:8080 bash run.sh"',
-            '  echo ""',
-            '  exit 1',
-            'fi',
-            'mkdir outputs',
-            `mkdir -p ${DATA_DIR}\n`
-        ].join('\n');
-
-        const assetPaths = files.getUserAssetPaths();
-        const configs = this.getAllStorageConfigs();
-        for (let i = assetPaths.length; i--;) {
-            const dataPath = assetPaths[i];
-            const dataInfo = files.getUserAsset(dataPath);
-            const url = await Storage.getDownloadURL(dataInfo, this.logger, configs);
-            runsh += `wget $DEEPFORGE_URL${url} -O ${dataPath}\n`;
+        let runDebug = Templates.RUN_DEBUG;
+        if (!this.settings.enableJobCaching) {
+            runDebug = `// Created at ${Date.now()}\n` + runDebug;
         }
-
-        runsh += 'python main.py';
-        files.addFile('run.sh', runsh);
-        return runsh;
+        files.addFile('run-debug.js', runDebug);
     };
 
     GenerateJob.prototype.createDataMetadataFile = async function (files) {

--- a/src/plugins/GenerateJob/templates/index.js
+++ b/src/plugins/GenerateJob/templates/index.js
@@ -1,6 +1,7 @@
 /*globals define*/
 define([
     'text!./start.js',
+    'text!./run-debug.js',
     'text!./main.ejs',
     'text!./deepforge.ejs',
     'text!./backend_deepforge.py',
@@ -10,6 +11,7 @@ define([
     'text!./utils.build.js',
 ], function(
     START,
+    RUN_DEBUG,
     MAIN,
     DEEPFORGE_SERIALIZATION,
     MATPLOTLIB_BACKEND,
@@ -21,6 +23,7 @@ define([
 
     return {
         START,
+        RUN_DEBUG,
         MAIN,
         SERIALIZE,
         DEEPFORGE_SERIALIZATION,

--- a/src/plugins/GenerateJob/templates/run-debug.js
+++ b/src/plugins/GenerateJob/templates/run-debug.js
@@ -1,0 +1,60 @@
+/*
+ * Script for manually running jobs locally. Run with:
+ *
+ *     node run-debug.js
+ *
+ */
+const fs = require('fs');
+const path = require('path');
+const {promisify} = require('util');
+const mkdir = promisify(fs.mkdir);
+const writeFile = promisify(fs.writeFile);
+const {spawn} = require('child_process');
+
+const Config = require('./config.json');
+process.env.DEEPFORGE_HOST = Config.HOST;
+const inputData = require('./input-data.json');
+
+const requirejs = require('requirejs');
+requirejs([
+    './utils.build',
+], function(
+    Utils,
+) {
+    const {Storage} = Utils;
+    main();
+
+    async function main() {
+        await tryMkdir(fromRelative('outputs'));
+        await tryMkdir(fromRelative('artifacts'));
+
+        const dataFetchTasks = Object.entries(inputData)
+            .map(input => fetchInputData.apply(null, input));
+
+        await Promise.all(dataFetchTasks);
+
+        const spawnOptions = {
+            detached: true,
+            stdio: [process.stdin, process.stdout, process.stderr],
+            cwd: __dirname
+        };
+        spawn('python', [fromRelative('main.py')], spawnOptions);
+    }
+
+    function nop() {
+    }
+
+    async function fetchInputData(filename, dataInfo) {
+        const buffer = await Storage.getFile(dataInfo, null, Config.storageConfigs);
+        filename = fromRelative(filename);
+        await writeFile(filename, buffer);
+    }
+
+    function fromRelative(filename) {
+        return path.join(__dirname, filename);
+    }
+
+    async function tryMkdir(filename) {
+        await mkdir(filename).catch(nop);
+    }
+});

--- a/src/visualizers/widgets/ArtifactIndex/ArtifactIndexWidget.js
+++ b/src/visualizers/widgets/ArtifactIndex/ArtifactIndexWidget.js
@@ -57,7 +57,8 @@ define([
                 const config = await this.getAuthenticationConfig(desc.dataInfo);
                 try {
                     const url = await this.getDownloadURL(desc.id, config);
-                    this.download(desc.name, url);
+                    const filename = desc.name.includes('.') ? desc.name : desc.name + '.dat';
+                    this.download(filename, url);
                 } catch (err) {
                     const msg = `Unable to fetch data: ${err.message}`;
                     Materialize.toast(msg, 4000);


### PR DESCRIPTION
This also updates the SciServer Files storage adapter to use the default implementation.

One downside of this approach is that it does not know when the URL is no longer required to be active. As a result `revokeObjectURL` is never called so blob URLs will be maintained until the document is unloaded. For more info, check out https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL.