### PR TITLE
Add aws-sdk to sciserver compute backend. Closes #1464

### DIFF
--- a/src/common/compute/backends/sciserver-compute/files/prepare-and-run.sh
+++ b/src/common/compute/backends/sciserver-compute/files/prepare-and-run.sh
@@ -2,7 +2,7 @@ RESULTS_DIR=$(pwd)
 JOB_DIR=$1
 
 cd $JOB_DIR;
-npm install requirejs@2.3.5 rimraf@^2.4.0 superagent@3.8.3 @babel/runtime@^7.7.2 q@1.5.1 node-fetch@2.6.0 agentkeepalive@3.4.1 > /dev/null
+npm install requirejs@2.3.5 rimraf@^2.4.0 superagent@3.8.3 @babel/runtime@^7.7.2 q@1.5.1 node-fetch@2.6.0 agentkeepalive@3.4.1 aws-sdk@2.624.0 > /dev/null
 pip install simplejson > /dev/null
 
 node start.js


### PR DESCRIPTION
This adds the aws-sdk dependency to the sciserver compute backend. Currently, this is the only compute backend with explicit dependencies installed as part of the process.

It would be good to improve how compute dependencies are handled but this adds the aws-sdk to the compute dependencies in their current state.