### PR TITLE
Add Docker image with extensions installed and publish it to docker hub. Closes #1484

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,3 +27,4 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "latest"
+          dockerfile: Dockerfile.kitchensink

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 1475-github-action
+      - 1484-deepforge-kitchensink
 
 jobs:
   publish:
@@ -12,10 +12,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Publish to docker hub
+      - name: Publish to docker hub (Vanilla)
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: deepforge/server
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest"
+
+      - name: Publish to docker hub (KitchenSink)
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: deepforge/kitchen-sink
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tags: "latest"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 1484-deepforge-kitchensink
 
 jobs:
   publish:

--- a/Dockerfile.kitchensink
+++ b/Dockerfile.kitchensink
@@ -1,6 +1,6 @@
 FROM deepforge/server:latest
 
-RUN source activate ${DEEPFORGE_CONDA_ENV} && pip install tensorflow keras pillow dill
+RUN source activate ${DEEPFORGE_CONDA_ENV} && pip install tensorflow==1.14 keras==2.2.5 pillow dill
 
 RUN deepforge extensions add deepforge-dev/deepforge-keras
 

--- a/Dockerfile.kitchensink
+++ b/Dockerfile.kitchensink
@@ -1,0 +1,6 @@
+FROM deepforge/server:latest
+
+RUN source activate ${DEEPFORGE_CONDA_ENV} && pip install tensorflow keras pillow dill
+
+RUN deepforge extensions add deepforge-dev/deepforge-keras
+


### PR DESCRIPTION
Builds on top of #1479 to create a `kitchen-sink` Docker image for deepforge server.
For now it is manually installing dependencies for deepforge-keras.  Should be changed when #1466 is resolved. Currently, pinpointing `tensorflow==1.14` and `keras==2.2.5` (https://github.com/deepforge-dev/deepforge-keras/issues/149) should also make some changes here.