### PR TITLE
Removed references to old env file. Closes #1520

### DIFF
--- a/bin/deepforge
+++ b/bin/deepforge
@@ -34,8 +34,7 @@ var Command = require('commander').Command,
         return dir;
     };
 
-const DEEPFORGE_CONDA_ENV = process.env.DEEPFORGE_CONDA_ENV || 'deepforge';
-
+const DEEPFORGE_CONDA_ENV = 'deepforge';
 const getDeepForgeServerCommand = function(useConda){
     if(useConda){
         return `${IS_WINDOWS ? 'conda': 'source'} activate ${DEEPFORGE_CONDA_ENV} && node`;

--- a/bin/deepforge
+++ b/bin/deepforge
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-const yaml = require('js-yaml'),
-    os = require('os'),
+const os = require('os'),
     IS_WINDOWS = os.type() === 'WINDOWS_NT',
     SHELL = IS_WINDOWS ? true : '/bin/bash',
     HOME_DIR = os.homedir(),
@@ -35,9 +34,7 @@ var Command = require('commander').Command,
         return dir;
     };
 
-const ENV_FILE = path.join(__dirname, '..', 'environment.yml'),
-DEEPFORGE_CONDA_ENV =
-    yaml.safeLoad(fs.readFileSync(ENV_FILE)).name || process.env.DEEPFORGE_CONDA_ENV;
+const DEEPFORGE_CONDA_ENV = process.env.DEEPFORGE_CONDA_ENV || 'deepforge';
 
 const getDeepForgeServerCommand = function(useConda){
     if(useConda){

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node ./bin/deepforge start",
-    "postinstall": "node utils/reinstall-extensions.js && node utils/build-job-utils.js && node utils/conda-utils.js",
+    "postinstall": "node utils/reinstall-extensions.js && node utils/build-job-utils.js",
     "start-dev": "NODE_ENV=dev node ./bin/deepforge start",
     "start-authenticated": "NODE_ENV=production ./bin/deepforge start",
     "server": "node ./bin/deepforge start --server",

--- a/utils/conda-utils.js
+++ b/utils/conda-utils.js
@@ -7,8 +7,7 @@ const {spawnSync, spawn} = require('child_process'),
     fs = require('fs'),
     yaml = require('js-yaml'),
     CONDA_COMMAND = 'conda',
-    SHELL = os.type() === 'Windows_NT' ? true: '/bin/bash',
-    ENV_FILE = path.join(__dirname, '..', 'environment.yml');
+    SHELL = os.type() === 'Windows_NT' ? true: '/bin/bash';
 
 const getCondaEnvs = function () {
     const envProcess = spawnSyncCondaProcess(['env', 'list']);
@@ -76,15 +75,6 @@ const spawnSyncCondaProcess = function (args) {
     });
 };
 
-const runMain = function () {
-    checkConda();
-    createOrUpdateEnvironment(ENV_FILE);
-};
-
 const CondaManager = {checkConda, createOrUpdateEnvironment};
-
-if (require.main === module) {
-    runMain();
-}
 
 module.exports = CondaManager;


### PR DESCRIPTION
This PR removes references to old environment.yml file. This also includes removing the execution of conda-utils as a binary in the postinstall script as this is updated in #1514