### PR TITLE
Add retries to storage adapter integration tests. Fixes #1575

### DIFF
--- a/test/integration/StorageBackends.spec.js
+++ b/test/integration/StorageBackends.spec.js
@@ -31,26 +31,35 @@ describe('Storage Features Test', function () {
     });
 
     for (const backend of storageBackends) {
-        it(`should execute putFile operation for the storage backend ${backend} `, async () => {
+        it(`should putFile using ${backend}`, async function() {
+            this.retries(maxRetries(backend));
             dataInfo = await clients[backend].putFile(`${TEST_STORAGE}/dummyFile`,
                 Buffer.from('A Quick Brown Fox Jumped over a lazy Dog.'));
         });
 
-        it(`should execute getFile operation for the storage backend ${backend}`, async () => {
+        it(`should getFile using ${backend}`, async function() {
+            this.retries(maxRetries(backend));
             await clients[backend].getFile(dataInfo);
         });
 
-        it(`should execute getCachePath operation for the storage backend ${backend}`, async () => {
+        it(`should getCachePath using ${backend}`, async () => {
             await clients[backend].getCachePath(dataInfo);
         });
 
-        it(`should execute deleteFile Operation for the storage backend ${backend}`, async () => {
+        it(`should deleteFile using ${backend}`, async function() {
+            this.retries(maxRetries(backend));
             await clients[backend].deleteFile(dataInfo);
         });
     }
 
-
     after(async function () {
         await server.stop();
     });
+
+    function maxRetries(backend) {
+        if (backend.includes('sciserver')) {
+            return 3;
+        }
+        return 1;
+    }
 });


### PR DESCRIPTION
I generally don't like adding retries to tests but, unfortunately, some of these storage backends are outside our control...