### PR TITLE
Move Deployment Script to the Repository (Closes #1596)

### DIFF
--- a/.deployment/README.md
+++ b/.deployment/README.md
@@ -1,7 +1,9 @@
 # Deployment Files
-This directory contains customizations to the standard deployment settings to accomodate the deployment machine.
+This directory contains customizations to the standard deployment settings to accommodate the deployment machine.
 
-Specifically, this contains a file with customizations to the standard docker-compose.yml file which allows us to modify the entrypoint and install a version of tensorflow [compatible with the CPU of the ddeployment machine](https://github.com/deepforge-dev/deepforge/issues/1561).
+The script `deploy-deepforge` is used for standard deployment of deepforge using github actions.
+
+Additionally, this contains a file with customizations to the standard docker-compose.yml file which allows us to modify the entrypoint and install a version of tensorflow [compatible with the CPU of the deployment machine](https://github.com/deepforge-dev/deepforge/issues/1561).
 
 The deployment is updated by first creating the custom docker compose file using [yaml-merge](https://github.com/alexlafroscia/yaml-merge):
 ```

--- a/.deployment/deploy-deepforge
+++ b/.deployment/deploy-deepforge
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-DEEPFORGE_DEPLOYMENT_DIR=$(realpath $(dirname "$0"))
-echo $DEEPFORGE_DEPLOYMENT_DIR
+DEEPFORGE_DEPLOYMENT_DIR="$(realpath "$(dirname "$0")")"
+. ~/.nvm/nvm.sh
 SERVER_NAME=server
 CUSTOM_OVERRIDE_FILE=docker-compose-overrides.yml
 
@@ -8,7 +8,7 @@ CUSTOM_OVERRIDE_FILE=docker-compose-overrides.yml
 export TOKEN_KEYS_DIR=/home/ubuntu/deepforge-deployment/token_keys
 export DEEPFORGE_DEPLOYMENT_DIR=$DEEPFORGE_DEPLOYMENT_DIR
 # Merging the custom override yml file
-yaml-merge docker-compose.yml $DEEPFORGE_DEPLOYMENT_DIR/$CUSTOM_OVERRIDE_FILE > custom-docker-compose.yml
+yaml-merge docker-compose.yml "$DEEPFORGE_DEPLOYMENT_DIR"/$CUSTOM_OVERRIDE_FILE > custom-docker-compose.yml
 
 # Pulling the latest docker image, stopping the server, removing and restarting it
 docker-compose --file custom-docker-compose.yml pull $SERVER_NAME

--- a/.deployment/deploy-deepforge
+++ b/.deployment/deploy-deepforge
@@ -5,7 +5,7 @@ SERVER_NAME=server
 CUSTOM_OVERRIDE_FILE=docker-compose-overrides.yml
 
 # TOKEN_KEYS_DIR to be mounted
-export TOKEN_KEYS_DIR=/home/ubuntu/deepforge-deployment/token_keys
+export TOKEN_KEYS_DIR=$TOKEN_KEYS_DIR
 export DEEPFORGE_DEPLOYMENT_DIR=$DEEPFORGE_DEPLOYMENT_DIR
 # Merging the custom override yml file
 yaml-merge docker-compose.yml "$DEEPFORGE_DEPLOYMENT_DIR"/$CUSTOM_OVERRIDE_FILE > custom-docker-compose.yml

--- a/.deployment/deploy-deepforge
+++ b/.deployment/deploy-deepforge
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 DEEPFORGE_DEPLOYMENT_DIR="$(realpath "$(dirname "$0")")"
-. ~/.nvm/nvm.sh
-SERVER_NAME=server
-CUSTOM_OVERRIDE_FILE=docker-compose-overrides.yml
+export DEEPFORGE_DEPLOYMENT_DIR
 
-# TOKEN_KEYS_DIR to be mounted
-export TOKEN_KEYS_DIR=$TOKEN_KEYS_DIR
-export DEEPFORGE_DEPLOYMENT_DIR=$DEEPFORGE_DEPLOYMENT_DIR
+. ~/.nvm/nvm.sh
+
+SERVER_NAME=server
+
 # Merging the custom override yml file
-yaml-merge docker-compose.yml "$DEEPFORGE_DEPLOYMENT_DIR"/$CUSTOM_OVERRIDE_FILE > custom-docker-compose.yml
+yaml-merge docker-compose.yml "$DEEPFORGE_DEPLOYMENT_DIR"/docker-compose-custom-overrides.yml > custom-docker-compose.yml
 
 # Pulling the latest docker image, stopping the server, removing and restarting it
 docker-compose --file custom-docker-compose.yml pull $SERVER_NAME

--- a/.deployment/deploy-deepforge
+++ b/.deployment/deploy-deepforge
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+DEEPFORGE_DEPLOYMENT_DIR=$(realpath $(dirname "$0"))
+echo $DEEPFORGE_DEPLOYMENT_DIR
+SERVER_NAME=server
+CUSTOM_OVERRIDE_FILE=docker-compose-overrides.yml
+
+# TOKEN_KEYS_DIR to be mounted
+export TOKEN_KEYS_DIR=/home/ubuntu/deepforge-deployment/token_keys
+export DEEPFORGE_DEPLOYMENT_DIR=$DEEPFORGE_DEPLOYMENT_DIR
+# Merging the custom override yml file
+yaml-merge docker-compose.yml $DEEPFORGE_DEPLOYMENT_DIR/$CUSTOM_OVERRIDE_FILE > custom-docker-compose.yml
+
+# Pulling the latest docker image, stopping the server, removing and restarting it
+docker-compose --file custom-docker-compose.yml pull $SERVER_NAME
+docker-compose stop $SERVER_NAME
+docker-compose rm -f $SERVER_NAME
+docker-compose --file custom-docker-compose.yml up -d $SERVER_NAME
+
+docker image prune -f

--- a/.deployment/deploy-deepforge
+++ b/.deployment/deploy-deepforge
@@ -7,7 +7,7 @@ export DEEPFORGE_DEPLOYMENT_DIR
 SERVER_NAME=server
 
 # Merging the custom override yml file
-yaml-merge docker-compose.yml "$DEEPFORGE_DEPLOYMENT_DIR"/docker-compose-custom-overrides.yml > custom-docker-compose.yml
+yaml-merge docker-compose.yml "$DEEPFORGE_DEPLOYMENT_DIR"/docker-compose-overrides.yml > custom-docker-compose.yml
 
 # Pulling the latest docker image, stopping the server, removing and restarting it
 docker-compose --file custom-docker-compose.yml pull $SERVER_NAME

--- a/.deployment/docker-compose-overrides.yml
+++ b/.deployment/docker-compose-overrides.yml
@@ -1,3 +1,8 @@
 services:
   server:
-    entrypoint: /deepforge/.deployment/dev-entrypoint.sh
+    entrypoint: /.deployment/dev-entrypoint.sh
+    volumes:
+      - "$HOME/.deepforge/blob:/data/blob"
+      - "${TOKEN_KEYS_DIR}:/token_keys"
+      - "${DEEPFORGE_DEPLOYMENT_DIR}:/.deployment"
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 /node_modules
+/.deployment

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,24 +10,24 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Publish to docker hub (server)
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: deepforge/server
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: "latest"
-
-      - name: Publish to docker hub (kitchen-sink)
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: deepforge/kitchen-sink
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: "latest"
-          dockerfile: Dockerfile.kitchensink
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Publish to docker hub (server)
+#        uses: elgohr/Publish-Docker-Github-Action@master
+#        with:
+#          name: deepforge/server
+#          username: ${{ secrets.DOCKER_USERNAME }}
+#          password: ${{ secrets.DOCKER_PASSWORD }}
+#          tags: "latest"
+#
+#      - name: Publish to docker hub (kitchen-sink)
+#        uses: elgohr/Publish-Docker-Github-Action@master
+#        with:
+#          name: deepforge/kitchen-sink
+#          username: ${{ secrets.DOCKER_USERNAME }}
+#          password: ${{ secrets.DOCKER_PASSWORD }}
+#          tags: "latest"
+#          dockerfile: Dockerfile.kitchensink
 
       - name: Deploy (dev.deepforge.org)
         uses: appleboy/ssh-action@master

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 1596-deployment-script
 
 jobs:
   publish:
@@ -39,6 +38,4 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
           script: |
             rm -rf deepforge && git clone git@github.com:deepforge-dev/deepforge && cd deepforge
-            git checkout -b 1596-deployment-script origin/1596-deployment-script
             chmod +x ./.deployment/deploy-deepforge && ./.deployment/deploy-deepforge
-

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 1596-deployment-script
 
 jobs:
   publish:
@@ -30,13 +31,17 @@ jobs:
 
       - name: Deploy (dev.deepforge.org)
         uses: appleboy/ssh-action@master
+        env:
+          TOKEN_KEYS_DIR: ${{ secrets.TOKEN_KEYS_DIR }}
         with:
           username: ${{ secrets.USERNAME }}
           host: ${{ secrets.HOST }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
           passphrase: ${{ secrets.PASSPHRASE }}
+          envs: TOKEN_KEYS_DIR
           script: |
             rm -rf deepforge && git clone git@github.com:deepforge-dev/deepforge && cd deepforge
+            git checkout -b 1596-deployment-script origin/1596-deployment-script
             chmod +x ./.deployment/deploy-deepforge && ./.deployment/deploy-deepforge
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
           port: ${{ secrets.PORT }}
           passphrase: ${{ secrets.PASSPHRASE }}
           script: |
-            rm -rf deepforge && git clone https:git@github.com:deepforge-dev/deepforge && cd deepforge
+            rm -rf deepforge && git clone git@github.com:deepforge-dev/deepforge && cd deepforge
             git checkout -b 1596-deployment-script origin/1596-deployment-script
             chmod +x ./.deployment/deploy-deepforge && ./.deployment/deploy-deepforge
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
           port: ${{ secrets.PORT }}
           passphrase: ${{ secrets.PASSPHRASE }}
           script: |
-            rf -rf deepforge && git clone https:git@github.com:deepforge-dev/deepforge && cd deepforge
+            rm -rf deepforge && git clone https:git@github.com:deepforge-dev/deepforge && cd deepforge
             git checkout -b 1596-deployment-script origin/1596-deployment-script
             chmod +x ./.deployment/deploy-deepforge && ./.deployment/deploy-deepforge
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 1596-deployment-script
 
 jobs:
   publish:
@@ -37,4 +38,8 @@ jobs:
           port: ${{ secrets.PORT }}
           passphrase: ${{ secrets.PASSPHRASE }}
           script: |
-            bash -ic deploy-deepforge
+            rf -rf deepforge && git clone https:git@github.com:deepforge-dev/deepforge && cd deepforge
+            git checkout -b 1596-deployment-script origin/1596-deployment-script
+            chmod +x ./.deployment/deploy-deepforge && ./.deployment/deploy-deepforge
+
+

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,8 +38,8 @@ jobs:
           port: ${{ secrets.PORT }}
           passphrase: ${{ secrets.PASSPHRASE }}
           script: |
+            source ~/.bashrc
             rm -rf deepforge && git clone git@github.com:deepforge-dev/deepforge && cd deepforge
             git checkout -b 1596-deployment-script origin/1596-deployment-script
             chmod +x ./.deployment/deploy-deepforge && ./.deployment/deploy-deepforge
-
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,36 +10,33 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Publish to docker hub (server)
-#        uses: elgohr/Publish-Docker-Github-Action@master
-#        with:
-#          name: deepforge/server
-#          username: ${{ secrets.DOCKER_USERNAME }}
-#          password: ${{ secrets.DOCKER_PASSWORD }}
-#          tags: "latest"
-#
-#      - name: Publish to docker hub (kitchen-sink)
-#        uses: elgohr/Publish-Docker-Github-Action@master
-#        with:
-#          name: deepforge/kitchen-sink
-#          username: ${{ secrets.DOCKER_USERNAME }}
-#          password: ${{ secrets.DOCKER_PASSWORD }}
-#          tags: "latest"
-#          dockerfile: Dockerfile.kitchensink
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish to docker hub (server)
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: deepforge/server
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest"
+
+      - name: Publish to docker hub (kitchen-sink)
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: deepforge/kitchen-sink
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: "latest"
+          dockerfile: Dockerfile.kitchensink
 
       - name: Deploy (dev.deepforge.org)
         uses: appleboy/ssh-action@master
-        env:
-          TOKEN_KEYS_DIR: ${{ secrets.TOKEN_KEYS_DIR }}
         with:
           username: ${{ secrets.USERNAME }}
           host: ${{ secrets.HOST }}
           key: ${{ secrets.KEY }}
           port: ${{ secrets.PORT }}
           passphrase: ${{ secrets.PASSPHRASE }}
-          envs: TOKEN_KEYS_DIR
           script: |
             rm -rf deepforge && git clone git@github.com:deepforge-dev/deepforge && cd deepforge
             git checkout -b 1596-deployment-script origin/1596-deployment-script

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 1596-deployment-script
 
 jobs:
   publish:
@@ -39,6 +38,5 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
           script: |
             rm -rf deepforge && git clone git@github.com:deepforge-dev/deepforge && cd deepforge
-            git checkout -b 1596-deployment-script origin/1596-deployment-script
             chmod +x ./.deployment/deploy-deepforge && ./.deployment/deploy-deepforge
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,6 @@ jobs:
           port: ${{ secrets.PORT }}
           passphrase: ${{ secrets.PASSPHRASE }}
           script: |
-            source ~/.bashrc
             rm -rf deepforge && git clone git@github.com:deepforge-dev/deepforge && cd deepforge
             git checkout -b 1596-deployment-script origin/1596-deployment-script
             chmod +x ./.deployment/deploy-deepforge && ./.deployment/deploy-deepforge

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ notes/
 src/worker
 token_keys/public_key
 token_keys/private_key
+# Created by deployment script
+custom-docker-compose.yml


### PR DESCRIPTION
Move deployment script to this repo and add `.deployment` directory to `.dockerignore`.

See https://github.com/deepforge-dev/deepforge/runs/561470471. For a successful action build.