### PR TITLE
Improved server port detection in GME storage client. Fixes #1629

### DIFF
--- a/src/common/storage/backends/StorageClient.js
+++ b/src/common/storage/backends/StorageClient.js
@@ -22,8 +22,8 @@ define([
 
     StorageHelpers.getServerURL = function () {
         const {port} = gmeConfig.server;
-        let url = require.isBrowser ? window.origin : process.env.DEEPFORGE_HOST;
-        url = url || `127.0.0.1:${port}`;
+        let url = require.isBrowser ? window.origin :
+            (process.env.DEEPFORGE_HOST || `http://127.0.0.1:${port}`);
         return [url.replace(/^https?:\/\//, ''), url.startsWith('https')];
     };
 

--- a/src/common/storage/backends/gme/Client.js
+++ b/src/common/storage/backends/gme/Client.js
@@ -9,19 +9,25 @@ define([
 
     const GMEStorage = function(/*name, logger*/) {
         StorageClient.apply(this, arguments);
+        const params = this.getBlobClientParams();
+        this.blobClient = new BlobClient(params);
+    };
+
+    GMEStorage.prototype = Object.create(StorageClient.prototype);
+
+    GMEStorage.prototype.getBlobClientParams = function() {
         const params = {
             logger: this.logger.fork('BlobClient')
         };
         if (!require.isBrowser) {
             const [url, isHttps] = this.getServerURL();
-            params.server = url.split(':')[0];
-            params.serverPort = +(url.split(':').pop());
+            const [server, port='80'] = url.split(':');
+            params.server = server;
+            params.serverPort = +port;
             params.httpsecure = isHttps;
         }
-        this.blobClient = new BlobClient(params);
+        return params;
     };
-
-    GMEStorage.prototype = Object.create(StorageClient.prototype);
 
     GMEStorage.prototype.getFile = async function(dataInfo) {
         const {data} = dataInfo;

--- a/test/unit/common/storage/backends/gme/Client.spec.js
+++ b/test/unit/common/storage/backends/gme/Client.spec.js
@@ -1,0 +1,15 @@
+describe('GME Storage Adapter', function() {
+    const testFixture = require('../../../../../globals');
+    const assert = require('assert');
+    const Storage = testFixture.requirejs('deepforge/storage/index');
+    const ID = 'gme';
+
+    it('should correctly generate blob client params', async function() {
+        const client = await Storage.getClient(ID);
+        const {DEEPFORGE_HOST} = process.env;
+        process.env.DEEPFORGE_HOST = 'https://editor.deepforge.org';
+        const params = client.getBlobClientParams();
+        process.env.DEEPFORGE_HOST = DEEPFORGE_HOST;
+        assert.equal(params.serverPort, 80);
+    });
+});


### PR DESCRIPTION
This ensures the server port is set to 80 if omitted from `DEEPFORGE_HOST`.