### PR TITLE
Hide sciserver password. Closes #1637

### DIFF
--- a/src/common/compute/backends/sciserver-compute/metadata.json
+++ b/src/common/compute/backends/sciserver-compute/metadata.json
@@ -16,7 +16,10 @@
             "description": "SciServer password",
             "value": "",
             "valueType": "string",
-            "readOnly": false
+            "readOnly": false,
+            "options": {
+                "isPassword": true
+            }
         },
         {
             "name": "volume",

--- a/src/common/storage/backends/sciserver-files/metadata.json
+++ b/src/common/storage/backends/sciserver-files/metadata.json
@@ -17,7 +17,10 @@
             "value": "",
             "valueType": "string",
             "readOnly": false,
-            "isAuth": true
+            "isAuth": true,
+            "options": {
+                "isPassword": true
+            }
         },
         {
             "name": "volume",


### PR DESCRIPTION
Here is an example of the resulting password field:
![DeepinScreenshot_select-area_20200414053504](https://user-images.githubusercontent.com/4982789/79215839-d1f10980-7e11-11ea-9fed-da73749c2ff1.png)
