### PR TITLE
Remove deployment env variables from docker-compose. Fixes #1755

### DIFF
--- a/.deployment/docker-compose-overrides.yml
+++ b/.deployment/docker-compose-overrides.yml
@@ -1,6 +1,9 @@
 services:
   server:
     entrypoint: /.deployment/dev-entrypoint.sh
+    environment:
+      - "DEEPFORGE_HOST=https://dev.deepforge.org"
+      - "DEEPFORGE_INTERACTIVE_COMPUTE_HOST=https://dev-compute.deepforge.org"
     volumes:
       - "$HOME/.deepforge/blob:/data/blob"
       - "${TOKEN_KEYS_DIR}:/token_keys"
@@ -12,6 +15,7 @@ services:
     environment:
       - "MONGO_URI=mongodb://mongo:27017/deepforge"
       - "DEEPFORGE_HOST=https://editor.deepforge.org"
+      - "DEEPFORGE_INTERACTIVE_COMPUTE_HOST=https://compute.deepforge.org"
       - "DEEPFORGE_PUBLIC_KEY=/token_keys/public_key"
       - "DEEPFORGE_PRIVATE_KEY=/token_keys/private_key"
     image: deepforge/kitchen-sink:stable

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,8 +8,6 @@ services:
   server:
     environment:
       - "MONGO_URI=mongodb://mongo:27017/deepforge"
-      - "DEEPFORGE_HOST=https://dev.deepforge.org"
-      - "DEEPFORGE_INTERACTIVE_COMPUTE_HOST=https://dev-compute.deepforge.org"
       - "DEEPFORGE_PUBLIC_KEY=/token_keys/public_key"
       - "DEEPFORGE_PRIVATE_KEY=/token_keys/private_key"
     image: deepforge/kitchen-sink:latest


### PR DESCRIPTION
Moved the `DEEPFORGE_HOST` environment variable to the deployment overrides. It was initially included there as a bit of an example as it is required to be overwritten before using some of the compute backends. However, it is easy to overlook when spinning up a local instance to test it out and checking `.deployment/docker-compose-overrides.yml` should provide a reasonable example if someone is looking for an example of how to configure a full-fledged custom deployment.