### PR TITLE
Add auth to config for gme blob. Fixes #1645

### DIFF
--- a/src/common/storage/backends/gme/Client.js
+++ b/src/common/storage/backends/gme/Client.js
@@ -7,9 +7,10 @@ define([
     BlobClient
 ) {
 
-    const GMEStorage = function(/*name, logger*/) {
+    const GMEStorage = function(id, name, logger, config={}) {
         StorageClient.apply(this, arguments);
         const params = this.getBlobClientParams();
+        params.apiToken = config.apiToken;
         this.blobClient = new BlobClient(params);
     };
 

--- a/src/common/storage/backends/gme/metadata.js
+++ b/src/common/storage/backends/gme/metadata.js
@@ -18,6 +18,7 @@ define([
             valueType: 'string',
             readOnly: false,
             isAuth: true,
+            isRequiredForBrowser: false,
         });
     }
     return metadata;

--- a/src/common/storage/backends/gme/metadata.js
+++ b/src/common/storage/backends/gme/metadata.js
@@ -1,0 +1,24 @@
+/*global define*/
+define([
+    'deepforge/gmeConfig',
+], function(
+    config,
+) {
+    const metadata = {
+        name: 'WebGME Blob Storage',
+        configStructure: []
+    };
+
+
+    if (config.authentication.enable) {
+        metadata.configStructure.push({
+            name: 'apiToken',
+            displayName: 'Access Token',
+            value: '',
+            valueType: 'string',
+            readOnly: false,
+            isAuth: true,
+        });
+    }
+    return metadata;
+});

--- a/src/common/storage/backends/gme/metadata.json
+++ b/src/common/storage/backends/gme/metadata.json
@@ -1,4 +1,0 @@
-{
-    "name": "WebGME Blob Storage",
-    "configStructure": []
-}

--- a/src/common/storage/index.js
+++ b/src/common/storage/index.js
@@ -3,7 +3,7 @@ define([
     'module',
     './backends/StorageBackend',
     'text!deepforge/storage/backends/sciserver-files/metadata.json',
-    'text!deepforge/storage/backends/gme/metadata.json',
+    'deepforge/storage/backends/gme/metadata',
     'text!deepforge/storage/backends/s3/metadata.json'
 ],function(
     module,
@@ -15,7 +15,7 @@ define([
     const Storage = {};
     const StorageMetadata = {};
     StorageMetadata['sciserver-files'] = JSON.parse(sciserverFiles);
-    StorageMetadata['gme'] = JSON.parse(gme);
+    StorageMetadata['gme'] = gme;
     StorageMetadata['s3'] = JSON.parse(s3);
     const STORAGE_BACKENDS = Object.keys(StorageMetadata);
 

--- a/src/common/viz/StorageHelpers.js
+++ b/src/common/viz/StorageHelpers.js
@@ -10,11 +10,19 @@ define([
 ) {
     const StorageHelpers = {};
 
-    StorageHelpers.getAuthenticationConfig = async function (dataInfo) {
+    StorageHelpers.getAuthenticationConfig = async function (dataInfo, runInBrowser=false) {
         const {backend} = dataInfo;
         const metadata = Storage.getStorageMetadata(backend);
         metadata.configStructure = metadata.configStructure
-            .filter(option => option.isAuth);
+            .filter(option => {
+                if (option.isAuth) {
+                    const isRequiredForBrowser = option.isRequiredForBrowser !== false;
+                    const isNodeJs = !runInBrowser;
+                    return isNodeJs || isRequiredForBrowser;
+                }
+                return false;
+            });
+
         if (metadata.configStructure.length) {
             const configDialog = new ConfigDialog();
             const title = `Authenticate with ${metadata.name}`;
@@ -26,7 +34,7 @@ define([
     };
 
     StorageHelpers.download = async function (dataInfo, dataName='data') {
-        const config = await StorageHelpers.getAuthenticationConfig(dataInfo);
+        const config = await StorageHelpers.getAuthenticationConfig(dataInfo, true);
         const storageAdapter = await Storage.getClient(dataInfo.backend, null, config);
         const storageName = Storage.getStorageMetadata(dataInfo.backend).name;
 


### PR DESCRIPTION
There is one remaining update that would be good to have:
- [x] if the storage adapter is to be used from the browser, then it doesn't need the access token since it is already authenticated... (Invalid tokens will still be successful since it will authenticate using the cookie instead.)