### PR TITLE
Remove authentication from JobOriginAPI. Fixes #1853

### DIFF
--- a/src/routers/JobOriginAPI/JobOriginAPI.js
+++ b/src/routers/JobOriginAPI/JobOriginAPI.js
@@ -27,7 +27,6 @@ var express = require('express'),
 function initialize(middlewareOpts) {
     var logger = middlewareOpts.logger.fork('JobOriginAPI'),
         gmeConfig = middlewareOpts.gmeConfig,
-        ensureAuthenticated = middlewareOpts.ensureAuthenticated,
         REQUIRED_FIELDS = ['hash', 'project', 'execution', 'job', 'nodeId', 'branch'];
 
     storage = require('../storage')(logger, gmeConfig);
@@ -39,9 +38,6 @@ function initialize(middlewareOpts) {
         res.setHeader('X-WebGME-Media-Type', 'webgme.v1');
         next();
     });
-
-    // Use ensureAuthenticated if the routes require authentication. (Can be set explicitly for each route.)
-    router.use('*', ensureAuthenticated);
 
     // Connect to mongo...
 


### PR DESCRIPTION
This is not an ideal long term fix as this should be changed to fit with the compute adapters better (related to https://github.com/deepforge-dev/deepforge/issues/1830). However, this should work in the meantime until the JobOriginAPI is updated.