### PR TITLE
Support for multiple plots in same operation (Closes #1975)

### DIFF
--- a/src/plugins/ExecuteJob/ExecuteJob.Metadata.js
+++ b/src/plugins/ExecuteJob/ExecuteJob.Metadata.js
@@ -102,7 +102,7 @@ define([
     ExecuteJob.prototype.onMetadataCommand = async function (job, cmd, id, content) {
         const MetadataClass = Metadata.getClassForCommand(cmd);
         const metadata = await this.getMetadataNodes(job);
-        const node = metadata.find(node => this.core.getAttribute(node, 'id')) ||
+        const node = metadata.find(node => +this.core.getAttribute(node, 'id') === id) ||
             await this.createNodeForMetadata(MetadataClass, job, id);
 
         const md = new MetadataClass(node, this.core, this.META);


### PR DESCRIPTION
Still needs some digging but I found that the following find function's 
https://github.com/deepforge-dev/deepforge/blob/974e833773f2494eb01d54fb3f458614a5711136/src/plugins/ExecuteJob/ExecuteJob.Metadata.js#L105-L106
condition is always truthy. This will thus override any other graphs that were created.