### PR TITLE
Ensure config "extensions" do not mutate the cached config. Fix #1985

### DIFF
--- a/config/config.extensions.js
+++ b/config/config.extensions.js
@@ -1,5 +1,7 @@
+const merge = require('lodash.merge');
 
 module.exports = config => {
+    config = merge({}, config);
     config.extensions = {};
     config.extensions.InteractiveComputeHost = process.env.DEEPFORGE_INTERACTIVE_COMPUTE_HOST;
     return config;


### PR DESCRIPTION
webgme apps appear to mutate the same, cached config. This is mostly fine except for when we are adding an extra key to the config and then it is validated when a dependency loads the webgme config. In this case, the addition of the extension info should not mutate the original.