### PR TITLE
Update in-memory value on dropdown refresh. Fixes #2047

### DIFF
--- a/src/common/viz/ConfigDialogEntries/CustomConfigEntries.js
+++ b/src/common/viz/ConfigDialogEntries/CustomConfigEntries.js
@@ -183,9 +183,9 @@ define([
                 stringEntry.valueItems = stringEntry.valueItems || [];
             }
 
-            const widget = await this.getEntryForProperty(stringEntry);
+            const entry = await this.getEntryForProperty(stringEntry);
             if (configEntry.valueItemsURL) {
-                const $dropdown = widget.el.find('select');
+                const $dropdown = entry.el.find('select');
                 const updateDropdown = async () => {
                     const valueItems = await this._fetchValueItems(configEntry);
                     $dropdown.empty();
@@ -202,13 +202,14 @@ define([
                             opt.innerText = '';
                             dropdown.appendChild(opt);
                         }
-                        this._addExtraValueItems(widget, configEntry);
+                        this._addExtraValueItems(entry, configEntry);
                     }
+                    entry.widget.setValue(dropdown.value);
                 };
                 $dropdown.on('focus', _.throttle(updateDropdown, 1000));
             }
 
-            return widget;
+            return entry;
         }
 
         async _fetchValueItems(configEntry) {


### PR DESCRIPTION
When the dropdown was programmatically refreshed after logging into SciServer, the widget's value was not correctly set (as programmatic updates to HTML elements don't trigger the `onchange` handler). As a result, the username being used was "Link account...". This has been updated to explicitly set the value for the widget.